### PR TITLE
put sorting of members beyond the asp-net-ef-border

### DIFF
--- a/Garage3.0/Controllers/MembersController.cs
+++ b/Garage3.0/Controllers/MembersController.cs
@@ -21,15 +21,8 @@ namespace Garage3.Controllers
         // GET: Members
         public async Task<IActionResult> Index()
         {
-            var members = await _context.Members
-                .Include(p => p.Vehicles)
-                .ToListAsync();
-
-            var sortedMembers = members
-                .OrderBy(p => p.FirstName.Substring(0, 2), StringComparer.Ordinal)
-                .ToList();
-
-            return View(sortedMembers);
+           
+            return View(await _context.Members.Include(p => p.Vehicles).OrderBy(p => EF.Functions.Collate(p.FirstName.Substring(0, 2), "Latin1_General_BIN")).ToListAsync());
         }
 
         // GET: Members/Details/5


### PR DESCRIPTION
Ok, I had already written this solution when I discovered that Ulf had pushed a different one, and it is too interesting to just throw away.

On the other hand, I do not really understand why none of the other collations I tried worked as specified, so doing it this way might be a bad idea for that reason.